### PR TITLE
Change price to integer on DB

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -15,6 +15,8 @@ class OffersController < ApplicationController
 
   def create
     @offer = Offer.new(offer_params)
+    integer_to_cents(@offer)
+    
     @offer.user = current_user
     if @offer.save
       redirect_to offer_path(@offer)
@@ -24,6 +26,10 @@ class OffersController < ApplicationController
   end
 
   private
+
+  def integer_to_cents(offer)
+    offer.price *= 100
+  end
 
   def offer_params
     params.require(:offer).permit(:instrument, :price, :location, photos: [])

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -15,8 +15,8 @@ class OffersController < ApplicationController
 
   def create
     @offer = Offer.new(offer_params)
-    integer_to_cents(@offer)
-    
+    convert_integer_to_cents(@offer)
+
     @offer.user = current_user
     if @offer.save
       redirect_to offer_path(@offer)
@@ -24,10 +24,14 @@ class OffersController < ApplicationController
       render 'new'
     end
   end
-
+  
+  def convert_cents_to_integer(offer)
+    offer.price / 100
+  end
+  
   private
-
-  def integer_to_cents(offer)
+  
+  def convert_integer_to_cents(offer)
     offer.price *= 100
   end
 

--- a/app/views/offers/new.html.erb
+++ b/app/views/offers/new.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for @offer do |f| %>
+<%= f.input :instrument %>
+<%= f.input :location %>
+<%= f.input :price %>
+<%= f.input :user %>
+<%= f.submit %>
+<% end %>

--- a/db/migrate/20210602155914_change_price_type_to_offers.rb
+++ b/db/migrate/20210602155914_change_price_type_to_offers.rb
@@ -1,0 +1,5 @@
+class ChangePriceTypeToOffers < ActiveRecord::Migration[6.0]
+  def change
+    change_column :offers, :price, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_06_01_213333) do
+ActiveRecord::Schema.define(version: 2021_06_02_155914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,13 +50,14 @@ ActiveRecord::Schema.define(version: 2021_06_01_213333) do
 
   create_table "offers", force: :cascade do |t|
     t.string "instrument"
-    t.decimal "price"
+    t.integer "price"
     t.string "location"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "description"
     t.string "picture_url"
+    t.string "available", default: "pending"
     t.index ["user_id"], name: "index_offers_on_user_id"
   end
 


### PR DESCRIPTION
I was talking with Vitor and he told me that we are supposed to store prices in our DB as INTEGERS and not as FLOATS or DECIMALS. 
Then we should do the conversion on the views and when we receive the prices from the user. 
To be able to do this we made two methods. convert_cents_to_integer and convert_integer_to_cents