### PR TITLE
Fix user photo crash

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,14 @@ class User < ApplicationRecord
   validates :last_name, presence: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+
+  def display_photo
+    if photo.attached?
+      photo.key
+    else
+      # Cloudinary default profile photo ID
+      "jun7vge4yvdmrhi3wti1.png" 
+    end
+  end
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,7 +19,6 @@
           <% if current_user.photo.attached? %>
             <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <% else %>
-          <%= cl_image_tag "jun7vge4yvdmrhi3wti1.png", width: 200, height: 200, crop: :fill %>
             <%= image_tag 'https://avatars.services.sap.com/images/rick.bates_small.png', class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <% end %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon d-brightyellow">
- <%= link_to root_path, class: "logo-link" do %>
-    <%= image_tag('https://res.cloudinary.com/rent-an-instrument/image/upload/v1622641825/egqkqzb8itklcsndvwhm.svg') %>
+  <%= link_to root_path, class: "logo-link" do %>
+      <%= image_tag('https://res.cloudinary.com/rent-an-instrument/image/upload/v1622641825/egqkqzb8itklcsndvwhm.svg') %>    
   <% end %>
 
    <%= render 'shared/searchbar' %>
@@ -16,7 +16,12 @@
         <%= link_to "Profile", manage_profile_path(current_user.username), class: "dropdown-item btn-navbar" %>
         <%= link_to "New offer", new_offer_path, class: "dropdown-item btn-navbar" %>
         <li class="nav-item dropdown" style="margin: 0 30px;">
-          <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% if current_user.photo.attached? %>
+            <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% else %>
+          <%= cl_image_tag "jun7vge4yvdmrhi3wti1.png", width: 200, height: 200, crop: :fill %>
+            <%= image_tag 'https://avatars.services.sap.com/images/rick.bates_small.png', class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% end %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "Sign out", destroy_user_session_path(current_user), method: :delete, class: "dropdown-item text-dark" %>
           </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,7 +19,7 @@
           <% if current_user.photo.attached? %>
             <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <% else %>
-            <%= image_tag 'https://avatars.services.sap.com/images/rick.bates_small.png', class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+            <%= cl_image_tag "jun7vge4yvdmrhi3wti1.png", class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <% end %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "Sign out", destroy_user_session_path(current_user), method: :delete, class: "dropdown-item text-dark" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon d-brightyellow">
   <%= link_to root_path, class: "logo-link" do %>
-      <%= image_tag('https://res.cloudinary.com/rent-an-instrument/image/upload/v1622641825/egqkqzb8itklcsndvwhm.svg') %>    
+      <%= image_tag('https://res.cloudinary.com/rent-an-instrument/image/upload/v1622641825/egqkqzb8itklcsndvwhm.svg') %> 
   <% end %>
 
    <%= render 'shared/searchbar' %>
@@ -16,11 +16,7 @@
         <%= link_to "Profile", manage_profile_path(current_user.username), class: "dropdown-item btn-navbar" %>
         <%= link_to "New offer", new_offer_path, class: "dropdown-item btn-navbar" %>
         <li class="nav-item dropdown" style="margin: 0 30px;">
-          <% if current_user.photo.attached? %>
-            <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-          <% else %>
-            <%= cl_image_tag "jun7vge4yvdmrhi3wti1.png", class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-          <% end %>
+            <%= cl_image_tag current_user.display_photo, class: "avatar dropdown-toggle", style: 'margin-right: 24px', id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "Sign out", destroy_user_session_path(current_user), method: :delete, class: "dropdown-item text-dark" %>
           </div>

--- a/app/views/users/manage.html.erb
+++ b/app/views/users/manage.html.erb
@@ -1,6 +1,6 @@
 <div class="user-banner d-flex justify-content-around align-items-center mt-4">
   <div class="user-pic">
-    <%= cl_image_tag current_user.photo.key, width: 300, class: "user-avatar" %>
+    <%= cl_image_tag current_user.display_photo, width: 300, class: "user-avatar" %>
   </div>
   <div class="info-block">
     <div class="user-id">


### PR DESCRIPTION
Party people,
yesterday when I was showing to Barbara after the presentation something went wrong with me (rsrs) and the photo wasn't sent inside the signup form. As expected, it crashed.
I just fixed it now.

- I created a method inside User.rb called 'display_photo' that checks if the user has a photo attached to display or if it should display the default one that I already uploaded to Cloudinary (See changes in User.rb). 

My idea is from now on whenever we need to display the user profile picture, instead of calling it 'current_user.photo.key', we should do 'current_user.display_photo' (see _navbar.html.erb and manage.html.erb). 